### PR TITLE
Fix binary name in directories with spaces

### DIFF
--- a/assignment_1/heat_seq/Makefile
+++ b/assignment_1/heat_seq/Makefile
@@ -1,5 +1,4 @@
-CURR_DIR=$(notdir $(basename $(shell pwd)))
-PRJ=$(CURR_DIR)
+PRJ=$(shell basename " $(shell pwd) " )
 SRC=$(wildcard *.c)
 OBJ=$(patsubst %.c,%.o,$(SRC))
 
@@ -19,7 +18,7 @@ $(PRJ): $(OBJ)
 	$(CC) $(CFLAGS) $(INCLUDES) $(OBJ) -o $@
 
 %.o: %.c
-	$(CC) $(CFLAGS) $(INCLUDES) -c $< -o $@ $(LIB)	
+	$(CC) $(CFLAGS) $(INCLUDES) -c $< -o $@ $(LIB)
 
 clean:
 	-rm -f $(OBJ) $(PRJ)


### PR DESCRIPTION
Make's `basename` command takes multiple arguments seperated by spaces,
however path may contain spaces as well. The result is that a "binary"
is created for each piece of the path seperated by spaces.