### PR TITLE
fix bugs: Clang -O2 couldn't calloc() and partially passed parameters

### DIFF
--- a/src/input.c
+++ b/src/input.c
@@ -38,7 +38,7 @@ static void readpgm_float(const char *fname,
                           size_t height, size_t width, double *data,
                           double dmin, double dmax)
 {
-    char format[2];
+    char format[3];
     FILE *f;
     unsigned imgw, imgh, maxv, v;
     size_t i;
@@ -49,11 +49,11 @@ static void readpgm_float(const char *fname,
 
     fscanf(f, "%2s", format);
     if (format[0] != 'P' || format[1] != '2') die("only ASCII PGM input is supported");
-    
+
     if (fscanf(f, "%u", &imgw) != 1 ||
         fscanf(f, "%u", &imgh) != 1 ||
         fscanf(f, "%u", &maxv) != 1) die("invalid input");
-    
+
     if (imgw != width || imgh != height) {
         fprintf(stderr, "input data size (%ux%u) does not match cylinder size (%zux%zu)\n",
                 imgw, imgh, width, height);
@@ -88,7 +88,7 @@ void read_parameters(struct parameters* p, int argc, char **argv)
     conductivity_fname = "pattern_100x150.pgm";
     tinit_fname = "pattern_100x150.pgm";
 
-    while ((ch = getopt(argc, argv, "c:e:hH:i:k:L:m:M:n:N:p:t:r")) != -1)
+    while ((ch = getopt(argc, argv, "c:e:hH:i:k:L:m:M:n:N:p:t:r:")) != -1)
     {
         switch(ch) {
         case 'c': conductivity_fname = optarg; break;
@@ -129,15 +129,12 @@ void read_parameters(struct parameters* p, int argc, char **argv)
     atexit(cleanup);
 
     if (!(tinit = calloc(p->N * p->M, sizeof(double)))) die("calloc");
-    if (tinit_fname) 
+    if (tinit_fname)
         readpgm_float(tinit_fname, p->N, p->M, tinit, p->io_tmin, p->io_tmax);
     p->tinit = tinit;
 
     if (!(conductivity = calloc(p->N * p->M, sizeof(double)))) die("calloc");
-    if (conductivity_fname) 
+    if (conductivity_fname)
         readpgm_float(conductivity_fname, p->N, p->M, conductivity, 0.0, 1.0);
     p->conductivity = conductivity;
 }
-
-
- 


### PR DESCRIPTION
1. When compiled with Clang -O2, the target executable would encounter
a problem that calloc() fails. This is because that in readpgm_float()
function, 'format' is declared as 'char [2]' to hold 2 characters. But
we still need 1 more place for '\0'. Clang with -O2 is affected by
this bounds overflow.

2. At least on macOS, programs compiled by either gcc or Clang can not
correctly read all the parameters. Add a colon to the 'getopt' expression
solves this problem.