### PR TITLE
fixed memory allocation, incomplete parameter read and changed default input file names to correct ones

### DIFF
--- a/src/input.c
+++ b/src/input.c
@@ -38,7 +38,7 @@ static void readpgm_float(const char *fname,
                           size_t height, size_t width, double *data,
                           double dmin, double dmax)
 {
-    char format[2];
+    char format[3];
     FILE *f;
     unsigned imgw, imgh, maxv, v;
     size_t i;
@@ -85,10 +85,10 @@ void read_parameters(struct parameters* p, int argc, char **argv)
     p->io_tmax = 100.0;
     p->nthreads = 1;
     p->printreports = 0;
-    conductivity_fname = "pattern_100x150.pgm";
-    tinit_fname = "pattern_100x150.pgm";
+    conductivity_fname = "../../images/pat1_100x150.pgm";
+    tinit_fname = "../../images/pat1_100x150.pgm";
 
-    while ((ch = getopt(argc, argv, "c:e:hH:i:k:L:m:M:n:N:p:t:r")) != -1)
+    while ((ch = getopt(argc, argv, "c:e:hH:i:k:L:m:M:n:N:p:t:r:")) != -1)
     {
         switch(ch) {
         case 'c': conductivity_fname = optarg; break;


### PR DESCRIPTION
I discovered some issues with memory allocation and did the same as in #2 (sadly I didn't see it earlier), this fixed the memory allocation and the problem that not all parameters were parsed correctly. Furthermore I changed the default values of the file path to the existing ones.